### PR TITLE
Check for webGL before loading data

### DIFF
--- a/element3/js/app.js
+++ b/element3/js/app.js
@@ -17,6 +17,9 @@ var weatherDataChosen = 'No Overlay';
 
 var App = (function () {
   function App() {
+    //Check if webGL is enabled
+    this.checkWebGL();
+
     //App variables
     var _this = this;
     this.coeff = 1000 * 60 * 10;
@@ -331,6 +334,17 @@ var App = (function () {
         }
       });      
     }
+  };
+
+  //Function that checks if webGL is enabled
+  App.prototype.checkWebGL = function () {
+    //Check that webGL is enabled before loading data
+    var testCanvas = document.createElement("canvas");
+    var testGL;
+    try {
+      testGl = testCanvas.getContext("webgl") || testCanvas.getContext("experimental-webgl");
+    }
+    catch (x) {}
   };
 
   //Function that calls all the data loading functions 

--- a/element3/js/app.js
+++ b/element3/js/app.js
@@ -344,7 +344,13 @@ var App = (function () {
     try {
       testGl = testCanvas.getContext("webgl") || testCanvas.getContext("experimental-webgl");
     }
-    catch (x) {}
+    catch (x) {
+      testGl = null;
+    }
+
+    if (testGl == null){
+      noWebGLErrorCatcher();
+    }
   };
 
   //Function that calls all the data loading functions 

--- a/element3/js/webGL_Canvas.js
+++ b/element3/js/webGL_Canvas.js
@@ -35,13 +35,8 @@ function initGL(canvas) {
       gl.viewportWidth = canvas.width;
       gl.viewportHeight = canvas.height;
     };
-  } catch (e) {
-    if (e instanceof TypeError) {
-      noWebGLErrorCatcher();
-    }
-    else {
-      throw e;
-    }
+  } catch (e) { //In case there are any other errors replace the map with video
+    noWebGLErrorCatcher();
   }
 }
 

--- a/element3/js/webGL_Canvas.js
+++ b/element3/js/webGL_Canvas.js
@@ -26,7 +26,7 @@ function latlonToPoint(latlon) {
 //Initialize the GL Canvas
 function initGL(canvas) {
   try {
-    gl = canvas.getContext("experimental-webgl");
+    gl = canvas.getContext("web-gl") || canvas.getContext("experimental-webgl");
     gl.viewportWidth = canvas.width;
     gl.viewportHeight = canvas.height;
 
@@ -36,9 +36,12 @@ function initGL(canvas) {
       gl.viewportHeight = canvas.height;
     };
   } catch (e) {
-  }
-  if (!gl) {
-    noWebGLErrorCatcher();
+    if (e instanceof TypeError) {
+      noWebGLErrorCatcher();
+    }
+    else {
+      throw e;
+    }
   }
 }
 


### PR DESCRIPTION
Checking when element3 checks for webGL so that it does it before it starts trying to load data.
See #15 
