### PR TITLE
Element2 border load fix

### DIFF
--- a/element2/css/index.css
+++ b/element2/css/index.css
@@ -105,17 +105,17 @@ label {
   max-width: none;
 }
 
-rect.bordered, circle.bordered {
-  stroke: #E6E6E6;
+circle.bordered {
+  stroke: #aaa;
   stroke-width:2px;   
 }
 
-text.mono {
+.axisText {
   font-size: 9pt;
   fill: #aaa;
 }
 
-text.mono2 {
+.legendText {
   font-size: 12pt;
   fill: #aaa;
 }

--- a/element2/js/aggregate_charts.js
+++ b/element2/js/aggregate_charts.js
@@ -1,27 +1,3 @@
-/* From http://stackoverflow.com/questions/9461621/how-to-format-a-number-as-2-5k-if-a-thousand-or-more-otherwise-900-in-javascrip */
-function nFormatter(num, digits) {
-  var si = [
-    { value: 1E18, symbol: "E" },
-    { value: 1E15, symbol: "P" },
-    { value: 1E12, symbol: "T" },
-    { value: 1E9,  symbol: "G" },
-    { value: 1E6,  symbol: "M" },
-    { value: 1E3,  symbol: "k" }
-  ], rx = /\.0+$|(\.[0-9]*[1-9])0+$/, i;
-  for (i = 0; i < si.length; i++) {
-    if (num >= si[i].value) {
-      return (num / si[i].value).toFixed(digits).replace(rx, "$1") + si[i].symbol;
-    }
-  }
-  return num.toFixed(digits).replace(rx, "$1");
-}
-
-function numberWithCommas(x) {
-    var parts = x.toString().split(".");
-    parts[0] = parts[0].replace(/\B(?=(\d{3})+(?!\d))/g, ",");
-    return parts.join(".");
-}
-
 /* Heatmap Chart -- A heatmap with speed on the y-axis and distance from rse om
  * the x-axis. The color of the box should be the percentage of dropped messages */
 var margin = { top: 50, right: 0, bottom: 0, left:50},
@@ -29,8 +5,9 @@ var margin = { top: 50, right: 0, bottom: 0, left:50},
     gridSize = Math.floor(width / 11),
     height = gridSize * 6 + margin.top
     legendElementWidth = (width - width*.2) / 9,
+    numCommaFormat = d3.format(","),
+    numShortFormat = d3.format(".3s")
     colors = ['#f7fbff', '#deebf7', '#c6dbef', '#9ecae1', '#6baed6', '#4292c6', '#2171b5', '#08519c', '#08306b']; //From colorbrewer2
-
 
 //Add the svg for the legend to the div
 var legendSvg = d3.select("#heatmapDiv")
@@ -97,8 +74,8 @@ var tip = d3.tip()
   .attr('class', 'd3-tip')
   .offset([-10, 0])
   .html(function (d) {
-    var string = '#Messages Sent: ' + numberWithCommas(d.p1Count);
-    string += '<br>#Messages Received: ' + numberWithCommas(d.rseCount);
+    var string = '#Messages Sent: ' + numCommaFormat(d.p1Count);
+    string += '<br>#Messages Received: ' + numCommaFormat(d.rseCount);
     string += '<br>%Messages Received: ' + (d.rseCount / d.p1Count).toFixed(2)*100 + '%';
     return string;
   });

--- a/element2/js/aggregate_charts.js
+++ b/element2/js/aggregate_charts.js
@@ -24,10 +24,10 @@ function numberWithCommas(x) {
 
 /* Heatmap Chart -- A heatmap with speed on the x-axis and distance from rse om
  * the y-axis. The color of the box should be the percentage of dropped messages */
-var margin = { top: 50, right: 0, bottom: 100, left:50},
+var margin = { top: 50, right: 0, bottom: 0, left:50},
     width = document.getElementById('heatmapDiv').offsetWidth - margin.left - margin.right,
-    height = 550 - margin.top - margin.bottom,
     gridSize = Math.floor(width / 11),
+    height = gridSize * 6 + margin.top
     legendElementWidth = (width - width*.2) / 9,
     buckets = 10,
     colors = ['#f7fbff', '#deebf7', '#c6dbef', '#9ecae1', '#6baed6', '#4292c6', '#2171b5', '#08519c', '#08306b'],
@@ -52,22 +52,11 @@ var svg = d3.select('#heatmapDiv')
   .append("svg")
   //responsive SVG needs these 2 attributes and no width and height attr
   .attr("preserveAspectRatio", "xMinYMin meet")
-  .attr("viewBox", "0 0 1028 550")
+  .attr("viewBox", "0 0 1028 "+(height+15))
   //class to make it responsive
   .classed("svg-content-responsive", true)
   .append('g')
     .attr('transform', 'translate(' + margin.left + ',' + margin.top + ')');
-
-var borderPath = svg.append("rect")
-  .attr("x", -48)
-  .attr("y", -47)
-  .attr("rx", 12)
-  .attr("ry", 12)
-  .attr("height", 545)
-  .attr("width", 975)
-  .style("stroke", "#aaa")
-  .style("fill", "none")
-  .style("stroke-width", 3);
 
 //Distance labels along the x-axis
 var distanceLabels = svg.selectAll('.distanceLabel')
@@ -78,7 +67,7 @@ var distanceLabels = svg.selectAll('.distanceLabel')
     .attr('y', 0)
     .style('text-anchor', 'middle')
     .attr('transform', 'translate(' + gridSize / 2 + ', -6)')
-    .attr('class', 'distanceLabel mono axis axis')
+    .attr('class', function (d, i) { return 'distanceLabel'+i+' mono axis axis'; })
 
 //Speed labels along the y-axis
 var speedLabels = svg.selectAll('.speedLabels')
@@ -89,7 +78,18 @@ var speedLabels = svg.selectAll('.speedLabels')
     .attr('y', function (d, i) { return i * gridSize; })
     .style('text-anchor', 'end')
     .attr('transform', 'translate(1,' + gridSize / 1.75 + ')')
-    .attr('class', 'speedLabel mono axis')
+    .attr('class', function (d, i) { return 'speedLabel'+i+' mono axis axis'; })
+
+var borderPath = svg.append("rect")
+  .attr("x", -48)
+  .attr("y", -47)
+  .attr("rx", 12)
+  .attr("ry", 12)
+  .attr("height", height)
+  .attr("width", width + margin.right + margin.left)
+  .style("stroke", "#aaa")
+  .style("fill", "none")
+  .style("stroke-width", 3);
 
 //Custom tooltip library
 var tip = d3.tip()

--- a/element2/js/aggregate_charts.js
+++ b/element2/js/aggregate_charts.js
@@ -35,18 +35,19 @@ var margin = { top: 50, right: 0, bottom: 0, left:50},
     distance = ['0 m', '50 m', '100 m', '150 m', '200 m', '250 m', '300 m', '350 m', '400 m', '450 m', '500 m']
     dataset = 'data/heat.csv';
 
-  console.log(width)
-  console.log(width+margin.left)
+    console.log(height)
+    console.log(gridSize)
+
 var svg2 = d3.select("#heatmapDiv")
   .classed("svg-container", true) //container class to make it responsive
   .append("svg")
   //responsive SVG needs these 2 attributes and no width and height attr
   .attr("preserveAspectRatio", "xMinYMin meet")
-  .attr("viewBox", "0 0 "+(width+margin.left+15)+" 150")
+  .attr("viewBox", "0 0 "+(width+margin.left+15)+" "+(gridSize+margin.top+15))
   //class to make it responsive
   .classed("svg-content-responsive", true)
   .append('g')
-    .attr('transform', 'translate(' + margin.left + ',' + margin.top + ')');
+    .attr('transform', 'translate(' + margin.left + ',' + margin.top/2 + ')');
 
 //Create the svg for the heatmap
 var svg = d3.select('#heatmapDiv')
@@ -58,7 +59,7 @@ var svg = d3.select('#heatmapDiv')
   //class to make it responsive
   .classed("svg-content-responsive", true)
   .append('g')
-    .attr('transform', 'translate(' + margin.left + ',' + margin.top + ')');
+    .attr('transform', 'translate(0' + margin.left + ',' + margin.top + ')');
 
 //Distance labels along the x-axis
 var distanceLabels = svg.selectAll('.distanceLabel')
@@ -198,42 +199,42 @@ d3.csv(dataset, function (heatCsv) {
     .data([0].concat(colorScale.quantiles()), function (d) { return d; });
   legend.enter().append("rect")
     .attr("x", function(d, i) { return legendElementWidth * i; })
-    .attr("y", gridSize/6)
+    .attr("y", sizeScale(sizeScale.domain()[1]) * gridSize / 2 - gridSize/1.75/2)
     .attr("width", legendElementWidth)
     .attr("height", gridSize/1.75)
     .style("fill", function(d, i) { return colors[i]; });
   legend.enter().append("text")
     .attr("class", "mono")
     .text(function(d, i) { return Math.round((d)*100) + " - " + Math.round((d+.11)*100) + "%"; })
-    .attr("x", function(d, i) { return (legendElementWidth * i)+legendElementWidth/4; })
-    .attr("y", 90);
+    .attr("x", function(d, i) { return (legendElementWidth * i); })
+    .attr("y", gridSize+5);
   legend.exit().remove();
 
   svg2.append("text")
     .attr("class", "mono2")
     .text("Total Messages Sent")
-    .attr("x", legendElementWidth * 9 + 25)
-    .attr("y", 0)
+    .attr("x", legendElementWidth * 9)
+    .attr("y", -3)
   svg2.append("circle")
-    .attr("cx", legendElementWidth * 9 + 25 + 20)
-    .attr("cy", 40)
-    .attr("r", 6)
+    .attr("cx", legendElementWidth * 9 + legendElementWidth/3)
+    .attr("cy", sizeScale(sizeScale.domain()[1]) * gridSize / 2)
+    .attr("r", sizeScale(sizeScale.domain()[0]) * gridSize / 2)
     .attr("class", "distance bordered")
     .style("fill", "rgb(247, 251, 255)")
   svg2.append("text")
     .attr("class", "mono")
     .text("200")
-    .attr("x", legendElementWidth * 9 + 25 + 12)
-    .attr("y", 90)
+    .attr("x", legendElementWidth * 9 + legendElementWidth/3 - sizeScale(sizeScale.domain()[0]) * gridSize / 1.5)
+    .attr("y", gridSize+5)
   svg2.append("circle")
-    .attr("cx", legendElementWidth * 10 + 25 + 20)
-    .attr("cy", 40)
-    .attr("r", 36)
+    .attr("cx", legendElementWidth * 10 + legendElementWidth/4)
+    .attr("cy", sizeScale(sizeScale.domain()[1]) * gridSize / 2)
+    .attr("r", sizeScale(sizeScale.domain()[1]) * gridSize / 2)
     .attr("class", "distance bordered")
     .style("fill", "rgb(247, 251, 255)")
   svg2.append("text")
     .attr("class", "mono")
     .text("1,200,000")
-    .attr("x", legendElementWidth * 10 + 20)
-    .attr("y", 90)
+    .attr("x", legendElementWidth * 10 + legendElementWidth/4 - sizeScale(sizeScale.domain()[1]) * gridSize / 3)
+    .attr("y", gridSize+5)
 });

--- a/element2/js/aggregate_charts.js
+++ b/element2/js/aggregate_charts.js
@@ -22,20 +22,18 @@ function numberWithCommas(x) {
     return parts.join(".");
 }
 
-/* Heatmap Chart -- A heatmap with speed on the x-axis and distance from rse om
- * the y-axis. The color of the box should be the percentage of dropped messages */
+/* Heatmap Chart -- A heatmap with speed on the y-axis and distance from rse om
+ * the x-axis. The color of the box should be the percentage of dropped messages */
 var margin = { top: 50, right: 0, bottom: 0, left:50},
     width = document.getElementById('heatmapDiv').offsetWidth - margin.left - margin.right,
     gridSize = Math.floor(width / 11),
     height = gridSize * 6 + margin.top
     legendElementWidth = (width - width*.2) / 9,
-    buckets = 10,
-    colors = ['#f7fbff', '#deebf7', '#c6dbef', '#9ecae1', '#6baed6', '#4292c6', '#2171b5', '#08519c', '#08306b'],
-    speed = ['0 mph', '10 mph', '20 mph', '30 mph', '40 mph', '>50 mph'],
-    distance = ['0 m', '50 m', '100 m', '150 m', '200 m', '250 m', '300 m', '350 m', '400 m', '450 m', '500 m']
-    dataset = 'data/heat.csv';
+    colors = ['#f7fbff', '#deebf7', '#c6dbef', '#9ecae1', '#6baed6', '#4292c6', '#2171b5', '#08519c', '#08306b']; //From colorbrewer2
 
-var svg2 = d3.select("#heatmapDiv")
+
+//Add the svg for the legend to the div
+var legendSvg = d3.select("#heatmapDiv")
   .classed("svg-container", true) //container class to make it responsive
   .append("svg")
   //responsive SVG needs these 2 attributes and no width and height attr
@@ -46,8 +44,8 @@ var svg2 = d3.select("#heatmapDiv")
   .append('g')
     .attr('transform', 'translate(' + margin.left + ',' + margin.top/2 + ')');
 
-//Create the svg for the heatmap
-var svg = d3.select('#heatmapDiv')
+//Add the svg for the chart to the div
+var chartSvg = d3.select('#heatmapDiv')
   .classed("svg-container", true) //container class to make it responsive
   .append("svg")
   //responsive SVG needs these 2 attributes and no width and height attr
@@ -59,7 +57,8 @@ var svg = d3.select('#heatmapDiv')
     .attr('transform', 'translate(0' + margin.left + ',' + margin.top + ')');
 
 //Distance labels along the x-axis
-var distanceLabels = svg.selectAll('.distanceLabel')
+var distance = ['0 m', '50 m', '100 m', '150 m', '200 m', '250 m', '300 m', '350 m', '400 m', '450 m', '500 m'];
+var distanceLabels = chartSvg.selectAll('.distanceLabel')
   .data(distance)
   .enter().append('text')
     .text(function (d) { return d; })
@@ -67,10 +66,11 @@ var distanceLabels = svg.selectAll('.distanceLabel')
     .attr('y', 0)
     .style('text-anchor', 'middle')
     .attr('transform', 'translate(' + gridSize / 2 + ', -6)')
-    .attr('class', function (d, i) { return 'distanceLabel'+i+' mono axis axis'; })
+    .attr('class', function (d, i) { return 'distanceLabel'+i+' axisText axis'; })
 
 //Speed labels along the y-axis
-var speedLabels = svg.selectAll('.speedLabels')
+var speed = ['0 mph', '10 mph', '20 mph', '30 mph', '40 mph', '>50 mph'];
+var speedLabels = chartSvg.selectAll('.speedLabels')
   .data(speed)
   .enter().append('text')
     .text(function (d) { return d; })
@@ -78,9 +78,10 @@ var speedLabels = svg.selectAll('.speedLabels')
     .attr('y', function (d, i) { return i * gridSize; })
     .style('text-anchor', 'end')
     .attr('transform', 'translate(1,' + gridSize / 1.75 + ')')
-    .attr('class', function (d, i) { return 'speedLabel'+i+' mono axis axis'; })
+    .attr('class', function (d, i) { return 'speedLabel'+i+' axisText axis'; })
 
-var borderPath = svg.append("rect")
+//Add border around chart svg
+var borderPath = chartSvg.append("rect")
   .attr("x", -48)
   .attr("y", -47)
   .attr("rx", 12)
@@ -101,10 +102,10 @@ var tip = d3.tip()
     string += '<br>%Messages Received: ' + (d.rseCount / d.p1Count).toFixed(2)*100 + '%';
     return string;
   });
-svg.call(tip);
+chartSvg.call(tip);
 
 //Load the data and populate the heatmap
-d3.csv(dataset, function (heatCsv) {
+d3.csv('data/heat.csv', function (heatCsv) {
   var data = [];
   //Get the data for p1 with speeds 0-45
   for (var i = 0; i < 55; i++) {
@@ -170,9 +171,9 @@ d3.csv(dataset, function (heatCsv) {
     .range([0.15,0.9]);
 
   //Create the circles for each speed/distance bin
-  var cards = svg.selectAll('.meter')
+  var circles = chartSvg.selectAll('.meter')
     .data(data, function (d) { return d.speed; })
-  cards.enter().append('circle')
+  circles.enter().append('circle')
     .attr("cx", function(d) { return (d.distance/50) * gridSize; })
     .attr("cy", function(d) { return (d.speed/10) * gridSize; })
     .attr("class", "distance bordered")
@@ -184,54 +185,55 @@ d3.csv(dataset, function (heatCsv) {
     .style("fill", function (d) { return (d.difference === 1 ? 'red' : colorScale(d.difference)); })
     .on('mouseover', tip.show)
     .on('mouseout', tip.hide);
-  cards.exit().remove();
+  circles.exit().remove();
 
-  //Create the legend
-  svg2.append("text")
-    .attr("class", "mono2")
+  //Create the legend for chart color
+  legendSvg.append("text")
+    .attr("class", "legendText")
     .text("Percentage of Messages Received")
     .attr("x", 0)
     .attr("y", -3);
-  var legend = svg2.selectAll('.legend')
+  var legend = legendSvg.selectAll('.legend')
     .data([0].concat(colorScale.quantiles()), function (d) { return d; });
   legend.enter().append("rect")
-    .attr("x", function(d, i) { return legendElementWidth * i; })
-    .attr("y", sizeScale(sizeScale.domain()[1]) * gridSize / 2 - gridSize/1.75/2)
-    .attr("width", legendElementWidth)
-    .attr("height", gridSize/1.75)
-    .style("fill", function(d, i) { return colors[i]; });
+    .attr("x", function(d, i) { return legendElementWidth * i; }) //One block per color
+    .attr("y", sizeScale(sizeScale.domain()[1]) * gridSize / 2 - gridSize/1.75/2) //Start slightly above the center of large circle
+    .attr("width", legendElementWidth) //Predetermined Width
+    .attr("height", gridSize/1.75) //Scale height with gridSize
+    .style("fill", function(d, i) { return colors[i]; }); 
   legend.enter().append("text")
-    .attr("class", "mono")
-    .text(function(d, i) { return Math.round((d)*100) + " - " + Math.round((d+.11)*100) + "%"; })
+    .attr("class", "axisText")
+    .text(function(d, i) { return Math.round((d)*100) + " - " + Math.round((d+.11)*100) + "%"; }) //Percent range
     .attr("x", function(d, i) { return (legendElementWidth * i); })
     .attr("y", gridSize+5);
   legend.exit().remove();
 
-  svg2.append("text")
-    .attr("class", "mono2")
+  //Create the legend for chart size
+  legendSvg.append("text")
+    .attr("class", "legendText")
     .text("Total Messages Sent")
-    .attr("x", legendElementWidth * 9)
+    .attr("x", legendElementWidth * 9) //There were 8 colors so start this at 9
     .attr("y", -3)
-  svg2.append("circle")
-    .attr("cx", legendElementWidth * 9 + legendElementWidth/3)
-    .attr("cy", sizeScale(sizeScale.domain()[1]) * gridSize / 2)
+  legendSvg.append("circle")
+    .attr("cx", legendElementWidth * 9 + legendElementWidth/3) //Add slight offset so not touching color legend
+    .attr("cy", sizeScale(sizeScale.domain()[1]) * gridSize / 2) //Center the small circle at same spot as large circle
     .attr("r", sizeScale(sizeScale.domain()[0]) * gridSize / 2)
     .attr("class", "distance bordered")
-    .style("fill", "rgb(247, 251, 255)")
-  svg2.append("text")
-    .attr("class", "mono")
+    .style("fill", "rgb(247, 251, 255)") //Fill with same color as lightest gradient
+  legendSvg.append("text")
+    .attr("class", "axisText")
     .text("200")
-    .attr("x", legendElementWidth * 9 + legendElementWidth/3 - sizeScale(sizeScale.domain()[0]) * gridSize / 1.5)
+    .attr("x", legendElementWidth * 9 + legendElementWidth/3 - sizeScale(sizeScale.domain()[0]) * gridSize / 1.5) //Place text starting just to the left of the circle
     .attr("y", gridSize+5)
-  svg2.append("circle")
+  legendSvg.append("circle")
     .attr("cx", legendElementWidth * 10 + legendElementWidth/4)
     .attr("cy", sizeScale(sizeScale.domain()[1]) * gridSize / 2)
     .attr("r", sizeScale(sizeScale.domain()[1]) * gridSize / 2)
     .attr("class", "distance bordered")
     .style("fill", "rgb(247, 251, 255)")
-  svg2.append("text")
-    .attr("class", "mono")
+  legendSvg.append("text")
+    .attr("class", "axisText")
     .text("1,200,000")
-    .attr("x", legendElementWidth * 10 + legendElementWidth/4 - sizeScale(sizeScale.domain()[1]) * gridSize / 3)
+    .attr("x", legendElementWidth * 10 + legendElementWidth/4 - sizeScale(sizeScale.domain()[1]) * gridSize / 3) //Place text starting just to the left of the circle
     .attr("y", gridSize+5)
 });

--- a/element2/js/aggregate_charts.js
+++ b/element2/js/aggregate_charts.js
@@ -35,12 +35,14 @@ var margin = { top: 50, right: 0, bottom: 0, left:50},
     distance = ['0 m', '50 m', '100 m', '150 m', '200 m', '250 m', '300 m', '350 m', '400 m', '450 m', '500 m']
     dataset = 'data/heat.csv';
 
+  console.log(width)
+  console.log(width+margin.left)
 var svg2 = d3.select("#heatmapDiv")
   .classed("svg-container", true) //container class to make it responsive
   .append("svg")
   //responsive SVG needs these 2 attributes and no width and height attr
   .attr("preserveAspectRatio", "xMinYMin meet")
-  .attr("viewBox", "0 0 1028 150")
+  .attr("viewBox", "0 0 "+(width+margin.left+15)+" 150")
   //class to make it responsive
   .classed("svg-content-responsive", true)
   .append('g')
@@ -52,7 +54,7 @@ var svg = d3.select('#heatmapDiv')
   .append("svg")
   //responsive SVG needs these 2 attributes and no width and height attr
   .attr("preserveAspectRatio", "xMinYMin meet")
-  .attr("viewBox", "0 0 1028 "+(height+15))
+  .attr("viewBox", "0 0 "+(width+margin.left+15)+" "+(height+15))
   //class to make it responsive
   .classed("svg-content-responsive", true)
   .append('g')

--- a/element2/js/aggregate_charts.js
+++ b/element2/js/aggregate_charts.js
@@ -35,9 +35,6 @@ var margin = { top: 50, right: 0, bottom: 0, left:50},
     distance = ['0 m', '50 m', '100 m', '150 m', '200 m', '250 m', '300 m', '350 m', '400 m', '450 m', '500 m']
     dataset = 'data/heat.csv';
 
-    console.log(height)
-    console.log(gridSize)
-
 var svg2 = d3.select("#heatmapDiv")
   .classed("svg-container", true) //container class to make it responsive
   .append("svg")

--- a/element2/js/app.js
+++ b/element2/js/app.js
@@ -125,7 +125,7 @@ var App = (function () {
           .style("fill", "white")
           .style("stroke", "black")
           .style("stroke-width", "3")
-          .text(function (d) { return d.value <= 0 ? "" : nFormatter(d.value,1); });
+          .text(function (d) { return d.value <= 0 ? "" : numShortFormat(d.value); });
         g.append("path")
           .attr("d", border)
           .attr("fill", "black");

--- a/element3/js/app.js
+++ b/element3/js/app.js
@@ -677,14 +677,12 @@ legend.onAdd = function () {
   div.innerHTML += '<div class="extra-marker-circle-black extra-marker" style="position:static;float:left;margin-right:15px"><i class="icon ion-checkmark icon-white" style="float:none"></i><br><br>Dry</div>';
   div.innerHTML += '<div class="extra-marker-circle-black extra-marker" style="position:static;float:left;margin-right:15px"><i class="icon ion-waterdrop icon-white" style="float:none"></i><br><br>Wet</div>';
   div.innerHTML += '<div class="extra-marker-circle-black extra-marker" style="position:static;float:left;margin-right:15px"><i class="icon ion-ios-snowy icon-white" style="float:none"></i><br><br>Snow</div>';
-    div.innerHTML += '<div class="extra-marker-circle-black extra-marker" style="position:static;float:left;margin-right:15px"><i class="icon ion-alert-circled icon-white" style="float:none"></i><br><br>Icy</div><br><br><br><br>';
-  //div.innerHTML += '<div class="extra-marker-circle-cadetblue extra-marker" style="position:static;float:left;margin-right:15px"><i class="icon ion-help icon-white" style="float:none"></i><br><br>N/A</div><br><br><br><br>';
+  div.innerHTML += '<div class="extra-marker-circle-black extra-marker" style="position:static;float:left;margin-right:15px"><i class="icon ion-alert-circled icon-white" style="float:none"></i><br><br>Icy</div><br><br><br><br>';
   div.innerHTML += '<img src="images/snowplow.png" height="18" width="18" style="margin-right:10px">Road Temperature Markers:<br>';
   div.innerHTML += '<div class="extra-marker-square-black extra-marker" style="position:static;float:left;margin-right:15px"><i class="icon ion-ios-sunny icon-white" style="float:none"></i><br><br><p style="margin:0px;width:50px;text-align:left">60-80&deg;F</p></div>';
   div.innerHTML += '<div class="extra-marker-square-black extra-marker" style="position:static;float:left;margin-right:15px"><i class="icon ion-ios-partlysunny icon-white" style="float:none"></i><br><br><p style="margin:0px;width:50px;text-align:left">32-60&deg;F</p></div>';
   div.innerHTML += '<div class="extra-marker-square-black extra-marker" style="position:static;float:left;margin-right:15px"><i class="icon ion-cloud icon-white" style="float:none"></i><br><br><p style="margin:0px;width:50px;text-align:left">0-32&deg;F</p></div>';
   div.innerHTML += '<div class="extra-marker-square-black extra-marker" style="position:static;float:left;margin-right:15px"><i class="icon ion-ios-snowy icon-white" style="float:none"></i><br><br>&lt;0&deg;F</p></div><br><br><br><br>';
-  //div.innerHTML += '<div class="extra-marker-square-cadetblue extra-marker" style="position:static;float:left;margin-right:15px"><i class="icon ion-help icon-white" style="float:none"></i><br><br>N/A</div><br><br><br><br>';
   div.style.visibility = "visible";
   return div;
 }


### PR DESCRIPTION
- Element2 heatmap was always setting height to the same value, meaning when the graph was rendered small due to smaller width, the svg and border were still full height.  Fixed that.
- Also made it so the chart will now resize outward (instead of only inward).
- Resized the legend.
