### PR TITLE
Remove horizontal scrollbar in data table

### DIFF
--- a/element5/css/element5.css
+++ b/element5/css/element5.css
@@ -27,38 +27,16 @@ body {
   }
 }
 
-/*.chart-title {
-  display: block;
-  font-size: 2rem;
-  padding-top: 1rem;
-}*/
-
-
-
 .display-container {
   font-size: 0.8em;
   color: black;
-/*  z-index: 1113; */
   position: relative;
   padding-top:5px;
   padding-left:10px;
 }
 
-/*@media (min-width: 550px) {
-  .display-container {
-    font-size: 0.9em;
-  }
-}*/
-
-/*.number-display {
-  z-index: 1112;
-  position: relative;
-}*/
-
 #chart-filters {
   padding: 0 0 0 10px;
-/*  max-height: 50px;*/
-/*  overflow: hidden;*/
   font-size: 0.8em;
 }
 
@@ -66,34 +44,20 @@ body {
   clear:left;
 }
 
-/*@media (min-width: 550px) {
-  #chart-filters {
-    max-height: 50px;
-  }
-}
-
-#floating-header {
-  position: fixed;
-  top: 0px;
-  width: 100%;
-  height: 162px;
-  z-index: 1001;
-  background-color: rgba(228, 226, 224, 0.9);
-}
-
-@media (min-width: 550px) {
-  #floating-header {
-    height: 60px;
-  }
-}*/
-
 .dataTables_wrapper {
   padding: 0px 20px 10px 20px;
-  overflow: scroll;
 }
 
 #data-table-chart tr td{
   border-bottom: none;
+  text-overflow: ellipsis;
+  overflow: hidden;
+  white-space: nowrap;
+}
+
+#data-table-chart {
+  table-layout: fixed;
+  word-wrap: break-word;
 }
 
 #data-table-chart_length select {
@@ -101,10 +65,10 @@ body {
 }
 
 .dataTables_wrapper .dataTables_paginate {
-    float: left;
-    text-align: right;
-    padding-top:25px;
-    padding-left:25px;
+  float: left;
+  text-align: right;
+  padding-top:25px;
+  padding-left:25px;
 }
 
 #data-table-chart_filter {
@@ -113,11 +77,6 @@ body {
 
 .dashboard-grid {
   padding:0;
-/*  max-width: 940px;*/
-}
-
-#data-table-chart_wrapper{
-  font-size:0.9em;
 }
 
 #data-table-chart_filter label {
@@ -129,6 +88,7 @@ body {
 }
 
 #data-table-chart_wrapper {
+  font-size:0.85em;
   padding-left:0;
   padding-right:10px;
 }
@@ -165,10 +125,10 @@ table thead th {
 }
 
 #sticky {
-    background-color:#fdb81e; /*#dce4ef*/
-    color: black;
-    font-weight:bold;
-    z-index: 9999;
+  background-color:#fdb81e; /*#dce4ef*/
+  color: black;
+  font-weight:bold;
+  z-index: 9999;
 }
 
 .easy-button-container {
@@ -198,5 +158,3 @@ table thead th {
   padding-left:0;
   margin-left:-5px;
 }
-
-

--- a/element5/js/fhwa5.js
+++ b/element5/js/fhwa5.js
@@ -440,8 +440,9 @@ function initViz(rde, locations) {
     // Function to handle rendering data set name/environment name with
     // hyperlinks
     var renderDataSetEnv = function (data, type) {
-        if ((type) === 'display') {
-            return '<a target="_blank" href="' + data.url + '">' + data.name
+        if (type === 'display') {
+            return '<a target="_blank" title="' + data.name
+                + '" href="' + data.url + '">' + data.name
                 + '</a>';
         }
         else {
@@ -451,8 +452,9 @@ function initViz(rde, locations) {
 
 
     dataTable = $('#data-table-chart').dataTable({
-        "lengthChange": false,
-        "pagingType": "numbers",
+        lengthChange: false,
+        pagingType: "numbers",
+        "autoWidth": false,
         dom: 'T<"clear-l"l><"clear-l"i><"clear-r"f><"clear-r"p>t',
         order: [[0, 'asc']],
         columnDefs: [{
@@ -464,16 +466,28 @@ function initViz(rde, locations) {
                 };
             },
             type: 'html',
+            width: '30%',
             render: renderDataSetEnv,
         }, {
             targets: 1,
             data: function (d) { return dataTableDateFormat(d.startDate); },
+            width: '10%',
         }, {
             targets: 2,
             data: function (d) { return dataTableDateFormat(d.endDate); },
+            width: '10%',
         }, {
             targets: 3,
             data: function (d) { return d.location; },
+            width: '10%',
+            render: function (data, type) {
+                if (type === 'display') {
+                    return '<span title="' + data + '">' + data + '</span>';
+                }
+                else {
+                    return data;
+                }
+            },
         }, {
             targets: 4,
             data: function (d) { return d.size; },
@@ -491,6 +505,7 @@ function initViz(rde, locations) {
             },
             type: 'html',
             render: renderDataSetEnv,
+            width: '30%',
         }]
     });
 


### PR DESCRIPTION
Set columns to fixed width and text-overflow: ellipsis.
Added titles to the columns which are most likely to overflow,
so the user can still access the full contents of the cell if
the cell overflows.

Prevents a horizontal scrollbar from showing up by ensuring
the table content doesn't increase its width.
